### PR TITLE
Prevent error if in combat

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -35,7 +35,9 @@ end
 
 -- Simplify mount summoning syntax
 local function mountSummon(list)
-    C_MountJournal.SummonByID(list[random(#list)])
+    if not UnitAffectingCombat("player") then
+        C_MountJournal.SummonByID(list[random(#list)])
+    end
 end
 
 ---


### PR DESCRIPTION
Fixes an error that pops up every time I try to mount up if in combat.

    Message: Interface\AddOns\ravMounts\Addon.lua:38: bad argument #1 to 'random' (interval is empty)
    Time: 01/30/18 00:16:48
    Count: 3
