### PR TITLE
Fix lua error when list is empty

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -36,7 +36,7 @@ end
 
 -- Simplify mount summoning syntax
 local function mountSummon(list)
-    if not UnitAffectingCombat("player") then
+    if not UnitAffectingCombat("player") and #list > 0 then
         C_MountJournal.SummonByID(list[random(#list)])
     end
 end


### PR DESCRIPTION
If you're in a zone where you can't fly and and inside where mounts are unusable, the add on will try and call mountSummon with an empty list resulting in an error on the random call.

